### PR TITLE
Support json message foramt for filebeat 8

### DIFF
--- a/filter-00-json.conf
+++ b/filter-00-json.conf
@@ -1,0 +1,8 @@
+filter {
+  if [message] =~ /^\s*\{.*\}\s*$/ {
+    json {
+      source => "message"
+      target => ""
+    }
+  }
+}


### PR DESCRIPTION
Filebeat 8 doesn't use plain text as logging format. It uses json. I think to put this filter here ist better than making two deferent pipelines, one for 7 one for 8.